### PR TITLE
Use features to control whether to check metadata consistency between file headers and central directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,9 @@ anyhow = "1.0"
 env_logger = "0.8"
 rayon = "1.0"
 memmap = "0.7"
-stderrlog = "0.4"
+stderrlog = "0.5.1"
 structopt = "0.3"
+
+[features]
+default = ["check-local-metadata"]
+check-local-metadata = []

--- a/src/read.rs
+++ b/src/read.rs
@@ -255,7 +255,7 @@ impl<'a> ZipArchive<'a> {
         let local_metadata =
             FileMetadata::from_local_header(&local_header, metadata.header_offset)?;
         debug!("Reading {:?}", local_metadata);
-        if *metadata != local_metadata {
+        if cfg!(feature = "check-local-metadata") && *metadata != local_metadata {
             return Err(ZipError::InvalidArchive(
                 "Central directory entry doesn't match local file header",
             ));


### PR DESCRIPTION
Some softwares, such as GitLab, may generate zip packages, in which information about file stored in local file header and central directory don't match, e.g. compressed_size and uncompressed_size are 0 in local file headers but correct in central directory.

As per piz is using information from central directory for extraction and information from local file headers are only used for validation, it would be great to have a switch on this behavior.

This PR has utilized [a Cargo feature called "features"](https://doc.rust-lang.org/cargo/reference/features.html) to control whether enable checking local file headers against central directory during compilation, and users may opt-out checking local metadata by `piz = { version = '0.3.1', default-features = false }`, or directly `piz = '0.3.1'` if they want to use the old and default behavior of checking local file headers against central directory.

This PR also updated dependency stderrlog to the latest available version.