### PR TITLE
Write test files to a temporary directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rayon = "1.0"
 memmap = "0.7"
 stderrlog = "0.5.1"
 structopt = "0.3"
+tempfile = "3"
 
 [features]
 default = ["check-local-metadata"]

--- a/tests/create-inputs.sh
+++ b/tests/create-inputs.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-set -euo pipefail
+set -exuo pipefail
 
-cd tests/inputs
+echo "Setting up test environment in $1 …"
+mkdir -p $1/tests/inputs
+cp -r tests/inputs/hello $1/tests/inputs/
+cd $1/tests/inputs
 
-echo "Setting up test environment..."
 rm -f *.zip
 
 # Hello Zip archive (small text files)


### PR DESCRIPTION
Hello, I'm packaging the `piz` crate for Debian.

When we run tests for Rust crates in Debian, the source code is read-only, therefore we need this patch to write the files to a temporary directory.

This is my first time writing rust. There is almost certainly a better and less fragile way to write this. Please feel free to adapt this patch, or throw it out and write a better one that achieves the same goal.

Thanks!
